### PR TITLE
Fix path endings in OpenAPI spec

### DIFF
--- a/docs/tradingview-openapi.yaml
+++ b/docs/tradingview-openapi.yaml
@@ -1,0 +1,17 @@
+openapi: 3.0.0
+info:
+  title: TradingView API
+  version: 1.0.0
+paths:
+  /accounts/signin/:
+    post:
+      summary: Sign in
+      responses:
+        '200':
+          description: OK
+  /pine_perm/list_users/:
+    post:
+      summary: List pine permission users
+      responses:
+        '200':
+          description: OK


### PR DESCRIPTION
## Summary
- add new OpenAPI specification file
- fix path definitions so they end with `/`

## Testing
- `openapi-spec-validator docs/tradingview-openapi.yaml`

------
https://chatgpt.com/codex/tasks/task_e_6840efab25a4832c9d487adfb15b31ff