### PR TITLE
Improve column and ticker docs

### DIFF
--- a/docs/tradingview-openapi.yaml
+++ b/docs/tradingview-openapi.yaml
@@ -409,6 +409,7 @@ components:
               type: array
               items:
                 type: string
+              description: Full symbol IDs like `EXCHANGE:SYMBOL` (regex `^[A-Z]+:[A-Z0-9._-]+$`).
         options:
           type: object
           properties:
@@ -418,7 +419,10 @@ components:
           type: array
           items:
             type: string
-          description: Dynamic column names, e.g. `name`, `close`, `RSI|240`.
+          description: |
+            Dynamic column names. Append a timeframe with `|PERIOD` as in `RSI|240`.
+            Valid PERIOD values: `1`, `5`, `15`, `60`, `240`, `1D`, `1W`, `1M`.
+            Daily-only indicators ignore the suffix; others support these periods.
         sort:
           type: object
           properties:


### PR DESCRIPTION
## Summary
- expand `columns` with timeframe list and clarify daily vs multi-timeframe indicators
- document ticker regex in `symbols.tickers`

## Testing
- `npm test` *(fails: vitest tests time out)*

------
https://chatgpt.com/codex/tasks/task_e_684165a7ebf8832ca6f3b16423fead16